### PR TITLE
Fix wrong speed multiplier

### DIFF
--- a/src/options.js
+++ b/src/options.js
@@ -60,7 +60,7 @@ export const MORTALITY_PERCENTATGE = 5
 export const TOTAL_TICKS = 1600
 export const TICKS_TO_RECOVER = 500
 export const TICKS_TO_INCUBATE = 100
-export const SPEED_FROM_UI_MULTIPLIER = 100
+export const SPEED_FROM_UI_MULTIPLIER = 0.01
 export const STATIC_PEOPLE_PERCENTATGE = 25
 
 export const resetRun = () => {


### PR DESCRIPTION
The old behaviour was to multiply the speed chosen on the UI by a 0.01 factor. The constant introduced has value 100, so the speed is super-sonic now.
With this fix the speed will be back to normal values.