### PR TITLE
Make sure triggering the stay at home/show deaths checkbox do not trigger an automated run

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -89,14 +89,10 @@ export const canvas = new window.p5(sketch => { // eslint-disable-line
     deathFilter.onclick = () => {
       RUN.filters.death = !RUN.filters.death
       document.getElementById('death-count').classList.toggle('show', RUN.filters.death)
-      startBalls()
-      resetValues()
     }
 
     stayHomeFilter.onchange = () => {
       RUN.filters.stayHome = !RUN.filters.stayHome
-      startBalls()
-      resetValues()
     }
   }
 


### PR DESCRIPTION
Make sure triggering the stay at home/show deaths checkbox do not trigger an automated run.
Also, make sure that when they're active the graph is diplayed (it wasn't).

![image](https://user-images.githubusercontent.com/1748918/81102476-98d72100-8f07-11ea-91dd-7ec3c2ef4b9f.png)
